### PR TITLE
DTR-5287: Implement formp for sdlt tax-calc flow

### DIFF
--- a/app/uk/gov/hmrc/formpproxy/sdlt/controllers/returns/TaxCalculationReturnsController.scala
+++ b/app/uk/gov/hmrc/formpproxy/sdlt/controllers/returns/TaxCalculationReturnsController.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.formpproxy.sdlt.controllers.returns
+
+import play.api.Logging
+import play.api.libs.json.{JsError, JsValue, Json}
+import play.api.mvc.{Action, ControllerComponents}
+import uk.gov.hmrc.formpproxy.actions.AuthAction
+import uk.gov.hmrc.formpproxy.sdlt.models.taxCalculation.*
+import uk.gov.hmrc.formpproxy.sdlt.services.ReturnService
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class TaxCalculationReturnsController @Inject() (
+  authorise: AuthAction,
+  service: ReturnService,
+  cc: ControllerComponents
+)(implicit ec: ExecutionContext)
+    extends BackendController(cc)
+    with Logging {
+
+  def updateTaxCalculation(): Action[JsValue] =
+    authorise.async(parse.json) { implicit request =>
+      request.body
+        .validate[UpdateTaxCalculationRequest]
+        .fold(
+          errs =>
+            Future.successful(BadRequest(Json.obj("message" -> "Invalid payload", "errors" -> JsError.toJson(errs)))),
+          body =>
+            service
+              .updateTaxCalculation(body)
+              .map { UpdateTaxCalculationReturn =>
+                Ok(Json.toJson(UpdateTaxCalculationReturn))
+              }
+              .recover { case t =>
+                logger.error("[updateTaxCalculation] failed", t)
+                InternalServerError(Json.obj("message" -> "Unexpected error"))
+              }
+        )
+    }
+
+}

--- a/app/uk/gov/hmrc/formpproxy/sdlt/models/taxCalculation/TaxCalculationModels.scala
+++ b/app/uk/gov/hmrc/formpproxy/sdlt/models/taxCalculation/TaxCalculationModels.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.formpproxy.sdlt.models.taxCalculation
+
+import play.api.libs.json.{Json, OFormat}
+
+case class UpdateTaxCalculationRequest(
+  stornId: String,
+  returnResourceRef: String,
+  amountPaid: Option[String] = None,
+  includesPenalty: Option[String] = None,
+  taxDue: Option[String] = None,
+  calcPenaltyDue: Option[String] = None,
+  calcTaxDue: Option[String] = None,
+  calcTaxRate1: Option[String] = None,
+  calcTaxRate2: Option[String] = None,
+  calcTotalTaxPenaltyDue: Option[String] = None,
+  calcTotalNpvTax: Option[String] = None,
+  calcTotalPremiumTax: Option[String] = None,
+  taxDuePremium: Option[String] = None,
+  taxDueNpv: Option[String] = None,
+  honestyDeclaration: Option[String] = None
+)
+
+object UpdateTaxCalculationRequest {
+  implicit val format: OFormat[UpdateTaxCalculationRequest] = Json.format[UpdateTaxCalculationRequest]
+}
+
+case class UpdateTaxCalculationReturn(
+  updated: Boolean
+)
+
+object UpdateTaxCalculationReturn {
+  implicit val format: OFormat[UpdateTaxCalculationReturn] = Json.format[UpdateTaxCalculationReturn]
+}

--- a/app/uk/gov/hmrc/formpproxy/sdlt/repositories/SdltFormpRepository.scala
+++ b/app/uk/gov/hmrc/formpproxy/sdlt/repositories/SdltFormpRepository.scala
@@ -30,6 +30,7 @@ import uk.gov.hmrc.formpproxy.sdlt.models.residency.*
 import uk.gov.hmrc.formpproxy.sdlt.models.transaction.*
 import uk.gov.hmrc.formpproxy.shared.utils.CallableStatementUtils.*
 import uk.gov.hmrc.formpproxy.sdlt.models.lease.*
+import uk.gov.hmrc.formpproxy.sdlt.models.taxCalculation.*
 
 import java.lang.Long
 import java.sql.{CallableStatement, Connection, ResultSet, Types}
@@ -70,6 +71,7 @@ trait SdltSource {
   def sdltCreateLease(request: CreateLeaseRequest): Future[CreateLeaseReturn]
   def sdltUpdateLease(request: UpdateLeaseRequest): Future[UpdateLeaseReturn]
   def sdltDeleteLease(request: DeleteLeaseRequest): Future[DeleteLeaseReturn]
+  def sdltUpdateTaxCalculation(request: UpdateTaxCalculationRequest): Future[UpdateTaxCalculationReturn]
 }
 
 private final case class SchemeRow(schemeId: Long, version: Option[Int], email: Option[String])
@@ -2361,6 +2363,75 @@ class SdltFormpRepository @Inject() (@NamedDatabase("sdlt") db: Database)(implic
       cs.execute()
 
       DeleteLeaseReturn(deleted = true)
+    } finally cs.close()
+  }
+
+  override def sdltUpdateTaxCalculation(request: UpdateTaxCalculationRequest): Future[UpdateTaxCalculationReturn] =
+    Future {
+      db.withTransaction { conn =>
+        callUpdateTaxCalculation(
+          conn = conn,
+          p_storn = request.stornId,
+          p_return_resource_ref = request.returnResourceRef.toLong,
+          p_amount_paid = request.amountPaid,
+          p_includes_penalty = request.includesPenalty,
+          p_tax_due = request.taxDue,
+          p_calc_penalty_due = request.calcPenaltyDue,
+          p_calc_tax_due = request.calcTaxDue,
+          p_calc_tax_rate1 = request.calcTaxRate1,
+          p_calc_tax_rate2 = request.calcTaxRate2,
+          p_calc_total_tax_penalty_due = request.calcTotalTaxPenaltyDue,
+          p_calc_total_npv_tax = request.calcTotalNpvTax,
+          p_calc_total_premium_tax = request.calcTotalPremiumTax,
+          p_tax_due_premium = request.taxDuePremium,
+          p_tax_due_npv = request.taxDueNpv,
+          p_honesty_declaration = request.honestyDeclaration
+        )
+      }
+    }
+
+  private def callUpdateTaxCalculation(
+    conn: Connection,
+    p_storn: String,
+    p_return_resource_ref: Long,
+    p_amount_paid: Option[String],
+    p_includes_penalty: Option[String],
+    p_tax_due: Option[String],
+    p_calc_penalty_due: Option[String],
+    p_calc_tax_due: Option[String],
+    p_calc_tax_rate1: Option[String],
+    p_calc_tax_rate2: Option[String],
+    p_calc_total_tax_penalty_due: Option[String],
+    p_calc_total_npv_tax: Option[String],
+    p_calc_total_premium_tax: Option[String],
+    p_tax_due_premium: Option[String],
+    p_tax_due_npv: Option[String],
+    p_honesty_declaration: Option[String]
+  ): UpdateTaxCalculationReturn = {
+
+    val cs = conn.prepareCall(
+      "{ call TAX_CALCULATION_PROC.Update_Tax(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) }"
+    )
+    try {
+      cs.setString(1, p_storn)
+      cs.setLong(2, p_return_resource_ref)
+      cs.setOptionalString(3, p_amount_paid)
+      cs.setOptionalString(4, p_includes_penalty)
+      cs.setOptionalString(5, p_tax_due)
+      cs.setOptionalString(6, p_calc_penalty_due)
+      cs.setOptionalString(7, p_calc_tax_due)
+      cs.setOptionalString(8, p_calc_tax_rate1)
+      cs.setOptionalString(9, p_calc_tax_rate2)
+      cs.setOptionalString(10, p_calc_total_tax_penalty_due)
+      cs.setOptionalString(11, p_calc_total_npv_tax)
+      cs.setOptionalString(12, p_calc_total_premium_tax)
+      cs.setOptionalString(13, p_tax_due_premium)
+      cs.setOptionalString(14, p_tax_due_npv)
+      cs.setOptionalString(15, p_honesty_declaration)
+
+      cs.execute()
+
+      UpdateTaxCalculationReturn(updated = true)
     } finally cs.close()
   }
 

--- a/app/uk/gov/hmrc/formpproxy/sdlt/services/ReturnService.scala
+++ b/app/uk/gov/hmrc/formpproxy/sdlt/services/ReturnService.scala
@@ -26,6 +26,7 @@ import uk.gov.hmrc.formpproxy.sdlt.models.residency.*
 import uk.gov.hmrc.formpproxy.sdlt.models.transaction.{UpdateTransactionRequest, UpdateTransactionReturn}
 import uk.gov.hmrc.formpproxy.sdlt.repositories.SdltFormpRepository
 import uk.gov.hmrc.formpproxy.sdlt.models.lease.*
+import uk.gov.hmrc.formpproxy.sdlt.models.taxCalculation.*
 
 import javax.inject.Inject
 import scala.concurrent.Future
@@ -112,5 +113,8 @@ class ReturnService @Inject() (repo: SdltFormpRepository) {
 
   def deleteLease(req: DeleteLeaseRequest): Future[DeleteLeaseReturn] =
     repo.sdltDeleteLease(req)
+
+  def updateTaxCalculation(req: UpdateTaxCalculationRequest): Future[UpdateTaxCalculationReturn] =
+    repo.sdltUpdateTaxCalculation(req)
 
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -95,6 +95,8 @@ POST       /filing/create/lease                                     uk.gov.hmrc.
 POST       /filing/update/lease                                     uk.gov.hmrc.formpproxy.sdlt.controllers.returns.LeaseReturnsController.updateLease()
 POST       /filing/delete/lease                                     uk.gov.hmrc.formpproxy.sdlt.controllers.returns.LeaseReturnsController.deleteLease()
 
+POST       /filing/update/tax-calculation                           uk.gov.hmrc.formpproxy.sdlt.controllers.returns.TaxCalculationReturnsController.updateTaxCalculation()
+
 # CHARITIES routes
 
 GET        /charities/:charityReference/unregulated-donations       uk.gov.hmrc.formpproxy.charities.controllers.UnregulatedDonationsController.getTotalUnregulatedDonations(charityReference: String)

--- a/it/test/uk/gov/hmrc/formpproxy/sdlt/DONOTDELETE/TaxCalculationFullWorkflowIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/formpproxy/sdlt/DONOTDELETE/TaxCalculationFullWorkflowIntegrationSpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//package uk.gov.hmrc.formpproxy.sdlt.DONOTDELETE
+//
+//import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+//import org.scalatest.matchers.must.Matchers
+//import org.scalatest.wordspec.AnyWordSpec
+//import play.api.http.Status.*
+//import play.api.libs.json.{JsValue, Json}
+//import uk.gov.hmrc.formpproxy.itutil.{ApplicationWithWiremock, AuthStub}
+//
+//class TaxCalculationFullWorkflowIntegrationSpec
+//  extends AnyWordSpec
+//    with Matchers
+//    with ScalaFutures
+//    with IntegrationPatience
+//    with ApplicationWithWiremock {
+//
+//  private val createReturnEndpoint         = "create/return"
+//  private val getReturnEndpoint            = "retrieve-return"
+//  private val updateTaxCalculationEndpoint = "filing/update/tax-calculation"
+//
+//  private def uniqueStorn(): String =
+//    System.currentTimeMillis().toString.takeRight(10)
+//
+//  "Complete Tax Calculation Workflow" should {
+//
+//    "create return (auto-seeds tax-calculation), update tax-calculation, get return, and verify updated values" in {
+//      AuthStub.authorised()
+//
+//      val storn = uniqueStorn()
+//
+//      println("\n\n=== STEP 1: Create Return (auto-seeds tax-calculation placeholder) ===")
+//      val createReturnPayload = Json.obj(
+//        "stornId"              -> storn,
+//        "purchaserIsCompany"   -> "N",
+//        "surNameOrCompanyName" -> "Smith",
+//        "houseNumber"          -> 100,
+//        "addressLine1"         -> "High Street",
+//        "addressLine2"         -> "Anytown",
+//        "postcode"             -> "AB12 3CD",
+//        "transactionType"      -> "RESIDENTIAL"
+//      )
+//
+//      val returnRes = postJson(createReturnEndpoint, createReturnPayload)
+//      returnRes.status mustBe CREATED
+//      val returnResourceRef = (returnRes.json \ "returnResourceRef").as[String]
+//      println(s"Created return with ID: $returnResourceRef for storn: $storn")
+//
+//      println("\n\n=== STEP 2: Update Tax Calculation (penalty included, full fields) ===")
+//      val updateTaxCalculationPayload = Json.obj(
+//        "stornId"                -> storn,
+//        "returnResourceRef"      -> returnResourceRef,
+//        "amountPaid"             -> "2000",
+//        "includesPenalty"        -> "YES",
+//        "taxDue"                 -> "8000",
+//        "calcPenaltyDue"         -> "500",
+//        "calcTaxDue"             -> "8000",
+//        "calcTaxRate1"           -> "3",
+//        "calcTaxRate2"           -> "7",
+//        "calcTotalTaxPenaltyDue" -> "8500",
+//        "calcTotalNpvTax"        -> "1000",
+//        "calcTotalPremiumTax"    -> "7500",
+//        "taxDuePremium"          -> "7500",
+//        "taxDueNpv"              -> "1000",
+//        "honestyDeclaration"     -> "YES"
+//      )
+//
+//      val updateRes = postJson(updateTaxCalculationEndpoint, updateTaxCalculationPayload)
+//      println(s"Update response status: ${updateRes.status}")
+//      println(s"Update response body: ${updateRes.json}")
+//      updateRes.status mustBe OK
+//      println("Tax calculation updated successfully")
+//
+//      println("\n\n=== STEP 3: Get Return (verify updated values) ===")
+//      val getReturnPayload = Json.obj(
+//        "storn"             -> storn,
+//        "returnResourceRef" -> returnResourceRef
+//      )
+//
+//      val getReturnRes = postJson(getReturnEndpoint, getReturnPayload)
+//      getReturnRes.status mustBe OK
+//      println("Retrieved return with tax-calculation:")
+//      println(Json.prettyPrint(getReturnRes.json))
+//
+//      val taxCalc = (getReturnRes.json \ "taxCalculation").toOption
+//      taxCalc must not be empty
+//
+//      val taxCalcData = taxCalc.get
+//      (taxCalcData \ "amountPaid").asOpt[String] mustBe Some("2000")
+//      (taxCalcData \ "includesPenalty").asOpt[String] mustBe Some("YES")
+//      (taxCalcData \ "taxDue").asOpt[String] mustBe Some("8000")
+//      (taxCalcData \ "calcPenaltyDue").asOpt[String] mustBe Some("500")
+//      (taxCalcData \ "calcTaxDue").asOpt[String] mustBe Some("8000")
+//      println("✓ Verified tax-calculation data matches updated values")
+//
+//      println("\n\n=== WORKFLOW COMPLETE ===")
+//    }
+//  }
+//}

--- a/test/uk/gov/hmrc/formpproxy/sdlt/controllers/TaxCalculationReturnsControllerSpec.scala
+++ b/test/uk/gov/hmrc/formpproxy/sdlt/controllers/TaxCalculationReturnsControllerSpec.scala
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.formpproxy.sdlt.controllers
+
+import org.mockito.ArgumentMatchers.eq as eqTo
+import org.mockito.Mockito.*
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.mvc.{ControllerComponents, PlayBodyParsers, Result}
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import uk.gov.hmrc.formpproxy.actions.{AuthAction, FakeAuthAction}
+import uk.gov.hmrc.formpproxy.sdlt.controllers.returns.TaxCalculationReturnsController
+import uk.gov.hmrc.formpproxy.sdlt.models.taxCalculation.*
+import uk.gov.hmrc.formpproxy.sdlt.services.ReturnService
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class TaxCalculationReturnsControllerSpec extends AnyFreeSpec with Matchers with ScalaFutures with MockitoSugar {
+
+  "TaxCalculationReturnsController updateTaxCalculation" - {
+
+    "returns 200 with updated true when service succeeds" in new Setup {
+      val request: UpdateTaxCalculationRequest = UpdateTaxCalculationRequest(
+        stornId = "STORN12345",
+        returnResourceRef = "100001",
+        amountPaid = Some("2000"),
+        includesPenalty = Some("YES"),
+        taxDue = Some("8000"),
+        calcPenaltyDue = Some("500"),
+        calcTaxDue = Some("8000"),
+        calcTaxRate1 = Some("3"),
+        calcTaxRate2 = Some("7"),
+        calcTotalTaxPenaltyDue = Some("8500"),
+        calcTotalNpvTax = Some("1000"),
+        calcTotalPremiumTax = Some("7500"),
+        taxDuePremium = Some("7500"),
+        taxDueNpv = Some("1000"),
+        honestyDeclaration = Some("YES")
+      )
+
+      val expectedResponse: UpdateTaxCalculationReturn = UpdateTaxCalculationReturn(updated = true)
+
+      when(mockService.updateTaxCalculation(eqTo(request)))
+        .thenReturn(Future.successful(expectedResponse))
+
+      val req: FakeRequest[JsValue] = makeJsonRequest(Json.toJson(request))
+      val res: Future[Result]       = controller.updateTaxCalculation()(req)
+
+      status(res) mustBe OK
+      contentType(res) mustBe Some(JSON)
+      (contentAsJson(res) \ "updated").as[Boolean] mustBe true
+
+      verify(mockService).updateTaxCalculation(eqTo(request))
+      verifyNoMoreInteractions(mockService)
+    }
+
+    "returns 200 with minimal update details" in new Setup {
+      val request: UpdateTaxCalculationRequest = UpdateTaxCalculationRequest(
+        stornId = "STORN99999",
+        returnResourceRef = "100002"
+      )
+
+      val expectedResponse: UpdateTaxCalculationReturn = UpdateTaxCalculationReturn(updated = true)
+
+      when(mockService.updateTaxCalculation(eqTo(request)))
+        .thenReturn(Future.successful(expectedResponse))
+
+      val req: FakeRequest[JsValue] = makeJsonRequest(Json.toJson(request))
+      val res: Future[Result]       = controller.updateTaxCalculation()(req)
+
+      status(res) mustBe OK
+      (contentAsJson(res) \ "updated").as[Boolean] mustBe true
+    }
+
+    "returns 200 with partial tax calculation details" in new Setup {
+      val request: UpdateTaxCalculationRequest = UpdateTaxCalculationRequest(
+        stornId = "STORN77777",
+        returnResourceRef = "100003",
+        amountPaid = Some("3000"),
+        taxDue = Some("3000"),
+        calcTaxDue = Some("3000"),
+        honestyDeclaration = Some("YES")
+      )
+
+      val expectedResponse: UpdateTaxCalculationReturn = UpdateTaxCalculationReturn(updated = true)
+
+      when(mockService.updateTaxCalculation(eqTo(request)))
+        .thenReturn(Future.successful(expectedResponse))
+
+      val req: FakeRequest[JsValue] = makeJsonRequest(Json.toJson(request))
+      val res: Future[Result]       = controller.updateTaxCalculation()(req)
+
+      status(res) mustBe OK
+      (contentAsJson(res) \ "updated").as[Boolean] mustBe true
+    }
+
+    "returns 400 when JSON body is empty" in new Setup {
+      val req: FakeRequest[JsValue] = makeJsonRequest(Json.obj())
+      val res: Future[Result]       = controller.updateTaxCalculation()(req)
+
+      status(res) mustBe BAD_REQUEST
+      (contentAsJson(res) \ "message").as[String] mustBe "Invalid payload"
+      verifyNoInteractions(mockService)
+    }
+
+    "returns 400 when stornId is missing" in new Setup {
+      val invalidJson: JsObject = Json.obj(
+        "returnResourceRef" -> "100001"
+      )
+
+      val req: FakeRequest[JsValue] = makeJsonRequest(invalidJson)
+      val res: Future[Result]       = controller.updateTaxCalculation()(req)
+
+      status(res) mustBe BAD_REQUEST
+      (contentAsJson(res) \ "message").as[String] mustBe "Invalid payload"
+      verifyNoInteractions(mockService)
+    }
+
+    "returns 400 when returnResourceRef is missing" in new Setup {
+      val invalidJson: JsObject = Json.obj(
+        "stornId" -> "STORN12345"
+      )
+
+      val req: FakeRequest[JsValue] = makeJsonRequest(invalidJson)
+      val res: Future[Result]       = controller.updateTaxCalculation()(req)
+
+      status(res) mustBe BAD_REQUEST
+      (contentAsJson(res) \ "message").as[String] mustBe "Invalid payload"
+      verifyNoInteractions(mockService)
+    }
+
+    "returns 500 with generic message on unexpected exception" in new Setup {
+      val request: UpdateTaxCalculationRequest = UpdateTaxCalculationRequest(
+        stornId = "STORN12345",
+        returnResourceRef = "100001"
+      )
+
+      when(mockService.updateTaxCalculation(eqTo(request)))
+        .thenReturn(Future.failed(new RuntimeException("Database timeout")))
+
+      val req: FakeRequest[JsValue] = makeJsonRequest(Json.toJson(request))
+      val res: Future[Result]       = controller.updateTaxCalculation()(req)
+
+      status(res) mustBe INTERNAL_SERVER_ERROR
+      (contentAsJson(res) \ "message").as[String] mustBe "Unexpected error"
+
+      verify(mockService).updateTaxCalculation(eqTo(request))
+      verifyNoMoreInteractions(mockService)
+    }
+  }
+
+  private trait Setup {
+    implicit val ec: ExecutionContext    = scala.concurrent.ExecutionContext.global
+    private val cc: ControllerComponents = stubControllerComponents()
+    private val parsers: PlayBodyParsers = cc.parsers
+    private def fakeAuth: AuthAction     = new FakeAuthAction(parsers)
+
+    val mockService: ReturnService = mock[ReturnService]
+    val controller                 = new TaxCalculationReturnsController(fakeAuth, mockService, cc)
+
+    def makeJsonRequest(body: JsValue): FakeRequest[JsValue] =
+      FakeRequest(POST, "/formp-proxy/sdlt/tax-calculation")
+        .withHeaders(CONTENT_TYPE -> JSON, ACCEPT -> JSON)
+        .withBody(body)
+  }
+}

--- a/test/uk/gov/hmrc/formpproxy/sdlt/models/TaxCalculationModelsSpec.scala
+++ b/test/uk/gov/hmrc/formpproxy/sdlt/models/TaxCalculationModelsSpec.scala
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.formpproxy.sdlt.models
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import play.api.libs.json.{JsSuccess, Json}
+import uk.gov.hmrc.formpproxy.sdlt.models.taxCalculation._
+
+class TaxCalculationModelsSpec extends AnyFreeSpec with Matchers {
+
+  "UpdateTaxCalculationRequest" - {
+
+    "must serialize to JSON correctly with all fields populated" in {
+      val request = UpdateTaxCalculationRequest(
+        stornId = "STORN12345",
+        returnResourceRef = "100001",
+        amountPaid = Some("2000"),
+        includesPenalty = Some("YES"),
+        taxDue = Some("8000"),
+        calcPenaltyDue = Some("500"),
+        calcTaxDue = Some("8000"),
+        calcTaxRate1 = Some("3"),
+        calcTaxRate2 = Some("7"),
+        calcTotalTaxPenaltyDue = Some("8500"),
+        calcTotalNpvTax = Some("1000"),
+        calcTotalPremiumTax = Some("7500"),
+        taxDuePremium = Some("7500"),
+        taxDueNpv = Some("1000"),
+        honestyDeclaration = Some("YES")
+      )
+
+      val json = Json.toJson(request)
+
+      (json \ "stornId").as[String] mustBe "STORN12345"
+      (json \ "returnResourceRef").as[String] mustBe "100001"
+      (json \ "amountPaid").as[String] mustBe "2000"
+      (json \ "includesPenalty").as[String] mustBe "YES"
+      (json \ "taxDue").as[String] mustBe "8000"
+      (json \ "calcPenaltyDue").as[String] mustBe "500"
+      (json \ "calcTaxDue").as[String] mustBe "8000"
+      (json \ "calcTaxRate1").as[String] mustBe "3"
+      (json \ "calcTaxRate2").as[String] mustBe "7"
+      (json \ "calcTotalTaxPenaltyDue").as[String] mustBe "8500"
+      (json \ "calcTotalNpvTax").as[String] mustBe "1000"
+      (json \ "calcTotalPremiumTax").as[String] mustBe "7500"
+      (json \ "taxDuePremium").as[String] mustBe "7500"
+      (json \ "taxDueNpv").as[String] mustBe "1000"
+      (json \ "honestyDeclaration").as[String] mustBe "YES"
+    }
+
+    "must serialize to JSON correctly with only required fields" in {
+      val request = UpdateTaxCalculationRequest(
+        stornId = "STORN99999",
+        returnResourceRef = "100002"
+      )
+
+      val json = Json.toJson(request)
+
+      (json \ "stornId").as[String] mustBe "STORN99999"
+      (json \ "returnResourceRef").as[String] mustBe "100002"
+      (json \ "amountPaid").toOption mustBe None
+      (json \ "honestyDeclaration").toOption mustBe None
+    }
+
+    "must deserialize from JSON correctly with all fields populated" in {
+      val json = Json.obj(
+        "stornId"                -> "STORN12345",
+        "returnResourceRef"      -> "100001",
+        "amountPaid"             -> "2000",
+        "includesPenalty"        -> "YES",
+        "taxDue"                 -> "8000",
+        "calcPenaltyDue"         -> "500",
+        "calcTaxDue"             -> "8000",
+        "calcTaxRate1"           -> "3",
+        "calcTaxRate2"           -> "7",
+        "calcTotalTaxPenaltyDue" -> "8500",
+        "calcTotalNpvTax"        -> "1000",
+        "calcTotalPremiumTax"    -> "7500",
+        "taxDuePremium"          -> "7500",
+        "taxDueNpv"              -> "1000",
+        "honestyDeclaration"     -> "YES"
+      )
+
+      val result = json.validate[UpdateTaxCalculationRequest]
+
+      result mustBe a[JsSuccess[_]]
+      val request = result.get
+
+      request.stornId mustBe "STORN12345"
+      request.returnResourceRef mustBe "100001"
+      request.amountPaid mustBe Some("2000")
+      request.includesPenalty mustBe Some("YES")
+      request.honestyDeclaration mustBe Some("YES")
+    }
+
+    "must deserialize from JSON correctly with only required fields" in {
+      val json = Json.obj(
+        "stornId"           -> "STORN99999",
+        "returnResourceRef" -> "100002"
+      )
+
+      val result = json.validate[UpdateTaxCalculationRequest]
+
+      result mustBe a[JsSuccess[_]]
+      val request = result.get
+
+      request.stornId mustBe "STORN99999"
+      request.returnResourceRef mustBe "100002"
+      request.amountPaid mustBe None
+      request.honestyDeclaration mustBe None
+    }
+
+    "must fail to deserialize when required field stornId is missing" in {
+      val json = Json.obj(
+        "returnResourceRef" -> "100001"
+      )
+
+      val result = json.validate[UpdateTaxCalculationRequest]
+
+      result.isError mustBe true
+    }
+
+    "must fail to deserialize when required field returnResourceRef is missing" in {
+      val json = Json.obj(
+        "stornId" -> "STORN12345"
+      )
+
+      val result = json.validate[UpdateTaxCalculationRequest]
+
+      result.isError mustBe true
+    }
+  }
+
+  "UpdateTaxCalculationReturn" - {
+
+    "must serialize to JSON correctly when updated is true" in {
+      val response = UpdateTaxCalculationReturn(updated = true)
+
+      val json = Json.toJson(response)
+
+      (json \ "updated").as[Boolean] mustBe true
+    }
+
+    "must serialize to JSON correctly when updated is false" in {
+      val response = UpdateTaxCalculationReturn(updated = false)
+
+      val json = Json.toJson(response)
+
+      (json \ "updated").as[Boolean] mustBe false
+    }
+
+    "must deserialize from JSON correctly when updated is true" in {
+      val json = Json.obj("updated" -> true)
+
+      val result = json.validate[UpdateTaxCalculationReturn]
+
+      result mustBe a[JsSuccess[_]]
+      result.get.updated mustBe true
+    }
+
+    "must fail to deserialize when updated field is missing" in {
+      val json = Json.obj()
+
+      val result = json.validate[UpdateTaxCalculationReturn]
+
+      result.isError mustBe true
+    }
+  }
+}

--- a/test/uk/gov/hmrc/formpproxy/sdlt/repositories/SdltFormpRepositorySpec.scala
+++ b/test/uk/gov/hmrc/formpproxy/sdlt/repositories/SdltFormpRepositorySpec.scala
@@ -29,6 +29,7 @@ import uk.gov.hmrc.formpproxy.sdlt.models.land.*
 import uk.gov.hmrc.formpproxy.sdlt.models.transaction.*
 import uk.gov.hmrc.formpproxy.sdlt.models.residency.*
 import uk.gov.hmrc.formpproxy.sdlt.models.lease.*
+import uk.gov.hmrc.formpproxy.sdlt.models.taxCalculation.*
 
 import java.sql.*
 
@@ -4561,6 +4562,146 @@ final class SdltFormpRepositorySpec extends SpecBase with SdltFormpRepoDataHelpe
 
       verify(cs).setString(1, "STORN-ABC-123")
       verify(cs).setLong(2, 100003L)
+      verify(cs).execute()
+    }
+  }
+
+  "sdltUpdateTaxCalculation" - {
+
+    "call Update_Tax stored procedure with correct parameters" in {
+      val db   = mock[Database]
+      val conn = mock[Connection]
+      val cs   = mock[CallableStatement]
+
+      when(db.withTransaction(anyArg[Connection => Any])).thenAnswer { inv =>
+        val f = inv.getArgument(0, classOf[Connection => Any]); f(conn)
+      }
+
+      when(
+        conn.prepareCall(
+          eqTo("{ call TAX_CALCULATION_PROC.Update_Tax(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) }")
+        )
+      )
+        .thenReturn(cs)
+
+      val repo = new SdltFormpRepository(db)
+
+      val request = UpdateTaxCalculationRequest(
+        stornId = "STORN12345",
+        returnResourceRef = "100001",
+        amountPaid = Some("2000"),
+        includesPenalty = Some("YES"),
+        taxDue = Some("8000"),
+        calcPenaltyDue = Some("500"),
+        calcTaxDue = Some("8000"),
+        calcTaxRate1 = Some("3"),
+        calcTaxRate2 = Some("7"),
+        calcTotalTaxPenaltyDue = Some("8500"),
+        calcTotalNpvTax = Some("1000"),
+        calcTotalPremiumTax = Some("7500"),
+        taxDuePremium = Some("7500"),
+        taxDueNpv = Some("1000"),
+        honestyDeclaration = Some("YES")
+      )
+
+      val result = repo.sdltUpdateTaxCalculation(request).futureValue
+
+      result.updated mustBe true
+
+      verify(conn).prepareCall(
+        "{ call TAX_CALCULATION_PROC.Update_Tax(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) }"
+      )
+      verify(cs).setString(1, "STORN12345")
+      verify(cs).setLong(2, 100001L)
+      verify(cs).setString(3, "2000")
+      verify(cs).setString(4, "YES")
+      verify(cs).setString(5, "8000")
+      verify(cs).setString(6, "500")
+      verify(cs).setString(7, "8000")
+      verify(cs).setString(8, "3")
+      verify(cs).setString(9, "7")
+      verify(cs).setString(10, "8500")
+      verify(cs).setString(11, "1000")
+      verify(cs).setString(12, "7500")
+      verify(cs).setString(13, "7500")
+      verify(cs).setString(14, "1000")
+      verify(cs).setString(15, "YES")
+      verify(cs).execute()
+      verify(cs).close()
+    }
+
+    "handle minimal update with no optional fields" in {
+      val db   = mock[Database]
+      val conn = mock[Connection]
+      val cs   = mock[CallableStatement]
+
+      when(db.withTransaction(anyArg[Connection => Any])).thenAnswer { inv =>
+        val f = inv.getArgument(0, classOf[Connection => Any]); f(conn)
+      }
+
+      when(conn.prepareCall(anyArg[String])).thenReturn(cs)
+
+      val repo = new SdltFormpRepository(db)
+
+      val request = UpdateTaxCalculationRequest(
+        stornId = "STORN99999",
+        returnResourceRef = "100002"
+      )
+
+      val result = repo.sdltUpdateTaxCalculation(request).futureValue
+
+      result.updated mustBe true
+
+      verify(cs).setString(1, "STORN99999")
+      verify(cs).setLong(2, 100002L)
+      verify(cs).setNull(3, Types.VARCHAR)
+      verify(cs).setNull(4, Types.VARCHAR)
+      verify(cs).setNull(5, Types.VARCHAR)
+      verify(cs).setNull(6, Types.VARCHAR)
+      verify(cs).setNull(7, Types.VARCHAR)
+      verify(cs).setNull(8, Types.VARCHAR)
+      verify(cs).setNull(9, Types.VARCHAR)
+      verify(cs).setNull(10, Types.VARCHAR)
+      verify(cs).setNull(11, Types.VARCHAR)
+      verify(cs).setNull(12, Types.VARCHAR)
+      verify(cs).setNull(13, Types.VARCHAR)
+      verify(cs).setNull(14, Types.VARCHAR)
+      verify(cs).setNull(15, Types.VARCHAR)
+      verify(cs).execute()
+    }
+
+    "handle update with only partial fields changed" in {
+      val db   = mock[Database]
+      val conn = mock[Connection]
+      val cs   = mock[CallableStatement]
+
+      when(db.withTransaction(anyArg[Connection => Any])).thenAnswer { inv =>
+        val f = inv.getArgument(0, classOf[Connection => Any]); f(conn)
+      }
+
+      when(conn.prepareCall(anyArg[String])).thenReturn(cs)
+
+      val repo = new SdltFormpRepository(db)
+
+      val request = UpdateTaxCalculationRequest(
+        stornId = "STORN77777",
+        returnResourceRef = "100003",
+        amountPaid = Some("3000"),
+        taxDue = Some("3000"),
+        calcTaxDue = Some("3000"),
+        honestyDeclaration = Some("YES")
+      )
+
+      val result = repo.sdltUpdateTaxCalculation(request).futureValue
+
+      result.updated mustBe true
+
+      verify(cs).setString(1, "STORN77777")
+      verify(cs).setLong(2, 100003L)
+      verify(cs).setString(3, "3000")
+      verify(cs).setString(5, "3000")
+      verify(cs).setString(7, "3000")
+      verify(cs).setString(15, "YES")
       verify(cs).execute()
     }
   }

--- a/test/uk/gov/hmrc/formpproxy/sdlt/services/ReturnServiceSpec.scala
+++ b/test/uk/gov/hmrc/formpproxy/sdlt/services/ReturnServiceSpec.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.formpproxy.sdlt.models.land.*
 import uk.gov.hmrc.formpproxy.sdlt.models.residency.*
 import uk.gov.hmrc.formpproxy.sdlt.models.transaction.*
 import uk.gov.hmrc.formpproxy.sdlt.models.lease.*
+import uk.gov.hmrc.formpproxy.sdlt.models.taxCalculation.*
 import uk.gov.hmrc.formpproxy.sdlt.models.returns.SdltReturnRecordResponse
 import uk.gov.hmrc.formpproxy.sdlt.repositories.{SdltFormpRepoDataHelper, SdltFormpRepository}
 
@@ -2952,6 +2953,79 @@ final class ReturnServiceSpec extends SpecBase with SdltFormpRepoDataHelper {
       ex mustBe boom
 
       verify(repo).sdltDeleteLease(eqTo(request))
+      verifyNoMoreInteractions(repo)
+    }
+  }
+
+  "ReturnService updateTaxCalculation" - {
+
+    "must delegate to repository " in {
+      val repo                                         = mock[SdltFormpRepository]
+      val service                                      = new ReturnService(repo)
+      val request: UpdateTaxCalculationRequest         = UpdateTaxCalculationRequest(
+        stornId = "STORN12345",
+        returnResourceRef = "100001",
+        amountPaid = Some("2000"),
+        includesPenalty = Some("YES"),
+        taxDue = Some("8000"),
+        calcPenaltyDue = Some("500"),
+        calcTaxDue = Some("8000"),
+        calcTaxRate1 = Some("3"),
+        calcTaxRate2 = Some("7"),
+        calcTotalTaxPenaltyDue = Some("8500"),
+        calcTotalNpvTax = Some("1000"),
+        calcTotalPremiumTax = Some("7500"),
+        taxDuePremium = Some("7500"),
+        taxDueNpv = Some("1000"),
+        honestyDeclaration = Some("YES")
+      )
+      val expectedResponse: UpdateTaxCalculationReturn = UpdateTaxCalculationReturn(updated = true)
+
+      when(repo.sdltUpdateTaxCalculation(eqTo(request)))
+        .thenReturn(Future.successful(expectedResponse))
+
+      val result: UpdateTaxCalculationReturn = service.updateTaxCalculation(request).futureValue
+      result mustBe expectedResponse
+
+      verify(repo).sdltUpdateTaxCalculation(eqTo(request))
+      verifyNoMoreInteractions(repo)
+    }
+
+    "must return false when update fails" in {
+      val repo                                         = mock[SdltFormpRepository]
+      val service                                      = new ReturnService(repo)
+      val request: UpdateTaxCalculationRequest         = UpdateTaxCalculationRequest(
+        stornId = "STORN99999",
+        returnResourceRef = "100002"
+      )
+      val expectedResponse: UpdateTaxCalculationReturn = UpdateTaxCalculationReturn(updated = false)
+
+      when(repo.sdltUpdateTaxCalculation(eqTo(request)))
+        .thenReturn(Future.successful(expectedResponse))
+
+      val result: UpdateTaxCalculationReturn = service.updateTaxCalculation(request).futureValue
+      result.updated mustBe false
+
+      verify(repo).sdltUpdateTaxCalculation(eqTo(request))
+      verifyNoMoreInteractions(repo)
+    }
+
+    "must propagate failures from repository" in {
+      val repo                                 = mock[SdltFormpRepository]
+      val service                              = new ReturnService(repo)
+      val request: UpdateTaxCalculationRequest = UpdateTaxCalculationRequest(
+        stornId = "STORN12345",
+        returnResourceRef = "100001"
+      )
+      val boom                                 = new RuntimeException("database timeout")
+
+      when(repo.sdltUpdateTaxCalculation(eqTo(request)))
+        .thenReturn(Future.failed(boom))
+
+      val ex: Throwable = service.updateTaxCalculation(request).failed.futureValue
+      ex mustBe boom
+
+      verify(repo).sdltUpdateTaxCalculation(eqTo(request))
       verifyNoMoreInteractions(repo)
     }
   }


### PR DESCRIPTION
# Adds /tax-calculation/update

## Requirements: 
https://confluence.tools.tax.service.gov.uk/spaces/RBD/pages/1155335332/I2+-+FormP+Proxy+Microservice
<img width="1019" height="595" alt="image" src="https://github.com/user-attachments/assets/84f1f960-2412-4d4d-aa56-dbfea0dbf5fc" />

## Testing: 

Output: `uk/gov/hmrc/formpproxy/sdlt/DONOTDELETE/TaxCalculationFullWorkflowIntegrationSpec.scala`

<img width="565" height="202" alt="image" src="https://github.com/user-attachments/assets/0aa99d80-a368-41af-a771-0405dae7e66a" />