### PR TITLE
DTR-5885: build return purging endpoints

### DIFF
--- a/app/uk/gov/hmrc/formpproxy/sdlt/controllers/returns/ReturnsController.scala
+++ b/app/uk/gov/hmrc/formpproxy/sdlt/controllers/returns/ReturnsController.scala
@@ -130,6 +130,54 @@ class ReturnsController @Inject() (
         )
     }
 
+  def getSDLTReturnsForPurge(): Action[JsValue] =
+    authorise.async(parse.json) { implicit request =>
+      request.body
+        .validate[GetReturnsForPurgeRequest]
+        .fold(
+          errs =>
+            Future.successful(
+              BadRequest(
+                Json.obj(
+                  "message" -> "Invalid JSON body",
+                  "errors"  -> JsError.toJson(errs)
+                )
+              )
+            ),
+          getReturnsForPurgeRequest =>
+            service
+              .getSDLTReturnsForPurge(getReturnsForPurgeRequest)
+              .map(rs => Ok(Json.toJson(rs)))
+              .recover {
+                case u: UpstreamErrorResponse =>
+                  Status(u.statusCode)(Json.obj("message" -> u.message))
+                case t: Throwable             =>
+                  logger.error("[getSDLTReturnsForPurge] failed", t)
+                  InternalServerError(Json.obj("message" -> "Unexpected error"))
+              }
+        )
+    }
+
+  def deleteSDLTReturn(): Action[JsValue] =
+    authorise.async(parse.json) { implicit request =>
+      request.body
+        .validate[DeleteReturnRequest]
+        .fold(
+          errs =>
+            Future.successful(BadRequest(Json.obj("message" -> "Invalid payload", "errors" -> JsError.toJson(errs)))),
+          body =>
+            service
+              .deleteSDLTReturn(body)
+              .map { deleteReturnReturn =>
+                Ok(Json.toJson(deleteReturnReturn))
+              }
+              .recover { case t =>
+                logger.error("[deleteSDLTReturn] failed", t)
+                InternalServerError(Json.obj("message" -> "Unexpected error"))
+              }
+        )
+    }
+
   def updateReturnVersion(): Action[JsValue] =
     authorise.async(parse.json) { implicit request =>
       request.body

--- a/app/uk/gov/hmrc/formpproxy/sdlt/models/DeleteReturnRequest.scala
+++ b/app/uk/gov/hmrc/formpproxy/sdlt/models/DeleteReturnRequest.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.formpproxy.sdlt.models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class DeleteReturnRequest(
+  storn: String,
+  returnResourceRef: String
+)
+
+object DeleteReturnRequest {
+  implicit val format: OFormat[DeleteReturnRequest] = Json.format[DeleteReturnRequest]
+}
+
+case class DeleteReturnReturn(
+  deleted: Boolean
+)
+
+object DeleteReturnReturn {
+  implicit val format: OFormat[DeleteReturnReturn] = Json.format[DeleteReturnReturn]
+}

--- a/app/uk/gov/hmrc/formpproxy/sdlt/models/GetReturnsForPurgeRequest.scala
+++ b/app/uk/gov/hmrc/formpproxy/sdlt/models/GetReturnsForPurgeRequest.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.formpproxy.sdlt.models
+
+import play.api.libs.json.{Json, OFormat}
+
+import java.time.LocalDate
+
+case class GetReturnsForPurgeRequest(
+  purgeDate: LocalDate
+)
+
+object GetReturnsForPurgeRequest {
+  implicit val format: OFormat[GetReturnsForPurgeRequest] = Json.format[GetReturnsForPurgeRequest]
+}

--- a/app/uk/gov/hmrc/formpproxy/sdlt/models/returns/ReturnsForPurgeResponse.scala
+++ b/app/uk/gov/hmrc/formpproxy/sdlt/models/returns/ReturnsForPurgeResponse.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.formpproxy.sdlt.models.returns
+
+import play.api.libs.json.{Json, OFormat}
+
+case class ReturnsForPurgeResponse(
+  returnsForPurge: List[ReturnForPurge]
+)
+
+object ReturnsForPurgeResponse {
+  implicit val format: OFormat[ReturnsForPurgeResponse] = Json.format[ReturnsForPurgeResponse]
+}
+
+case class ReturnForPurge(
+  storn: String,
+  returnResourceRef: String,
+  status: String
+)
+
+object ReturnForPurge {
+  implicit val format: OFormat[ReturnForPurge] = Json.format[ReturnForPurge]
+}

--- a/app/uk/gov/hmrc/formpproxy/sdlt/repositories/SdltFormpRepository.scala
+++ b/app/uk/gov/hmrc/formpproxy/sdlt/repositories/SdltFormpRepository.scala
@@ -22,7 +22,7 @@ import play.api.db.{Database, NamedDatabase}
 import uk.gov.hmrc.formpproxy.sdlt.models.*
 import uk.gov.hmrc.formpproxy.sdlt.models.agents.*
 import uk.gov.hmrc.formpproxy.sdlt.models.organisation.*
-import uk.gov.hmrc.formpproxy.sdlt.models.returns.{ReturnSummary, SdltReturnRecordResponse}
+import uk.gov.hmrc.formpproxy.sdlt.models.returns.{ReturnForPurge, ReturnSummary, ReturnsForPurgeResponse, SdltReturnRecordResponse}
 import uk.gov.hmrc.formpproxy.sdlt.models.vendor.*
 import uk.gov.hmrc.formpproxy.sdlt.models.purchaser.*
 import uk.gov.hmrc.formpproxy.sdlt.models.land.*
@@ -33,7 +33,7 @@ import uk.gov.hmrc.formpproxy.sdlt.models.lease.*
 import uk.gov.hmrc.formpproxy.sdlt.models.taxCalculation.*
 
 import java.lang.Long
-import java.sql.{CallableStatement, Connection, ResultSet, Types}
+import java.sql.{CallableStatement, Connection, Date, ResultSet, Types}
 import java.time.LocalDate
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -43,6 +43,8 @@ trait SdltSource {
   def sdltCreateReturn(request: CreateReturnRequest): Future[String]
   def sdltGetReturn(returnResourceRef: String, storn: String): Future[GetReturnRequest]
   def sdltGetReturns(request: GetReturnRecordsRequest): Future[SdltReturnRecordResponse]
+  def sdltGetReturnsForPurge(request: GetReturnsForPurgeRequest): Future[ReturnsForPurgeResponse]
+  def sdltDeleteReturn(request: DeleteReturnRequest): Future[DeleteReturnReturn]
   def sdltCreateVendor(request: CreateVendorRequest): Future[CreateVendorReturn]
   def sdltUpdateVendor(request: UpdateVendorRequest): Future[UpdateVendorReturn]
   def sdltDeleteVendor(request: DeleteVendorRequest): Future[DeleteVendorReturn]
@@ -269,6 +271,59 @@ class SdltFormpRepository @Inject() (@NamedDatabase("sdlt") db: Database)(implic
         } finally cs.close()
       }
     }
+  }
+
+  override def sdltGetReturnsForPurge(request: GetReturnsForPurgeRequest): Future[ReturnsForPurgeResponse] = {
+    logger.info(s"[SDLT] sdltGetReturnsForPurge($request)")
+    Future {
+      db.withConnection { conn =>
+        val cs = conn.prepareCall(
+          "{ call RETURN_PROCS.get_returns_for_purge(?, ?) }"
+        )
+        try {
+          cs.setDate(1, Date.valueOf(request.purgeDate))
+          cs.registerOutParameter(2, OracleTypes.CURSOR)
+          cs.execute()
+
+          val returnsForPurge: Seq[ReturnForPurge] = processResultSetSeq(cs, 2, processReturnForPurge)
+
+          ReturnsForPurgeResponse(returnsForPurge = returnsForPurge.toList)
+        } finally cs.close()
+      }
+    }
+  }
+
+  private def processReturnForPurge(rs: ResultSet): ReturnForPurge =
+    ReturnForPurge(
+      storn = rs.getString("storn"),
+      returnResourceRef = rs.getString("return_resource_ref"),
+      status = Option(rs.getString("status")).getOrElse("")
+    )
+
+  override def sdltDeleteReturn(request: DeleteReturnRequest): Future[DeleteReturnReturn] = Future {
+    db.withTransaction { conn =>
+      callDeleteReturn(
+        conn = conn,
+        p_storn = request.storn,
+        p_return_resource_ref = request.returnResourceRef.toLong
+      )
+    }
+  }
+
+  private def callDeleteReturn(
+    conn: Connection,
+    p_storn: String,
+    p_return_resource_ref: Long
+  ): DeleteReturnReturn = {
+
+    val cs = conn.prepareCall("{ call RETURN_PROCS.delete_return(?, ?) }")
+    try {
+      cs.setString(1, p_storn)
+      cs.setLong(2, p_return_resource_ref)
+      cs.execute()
+
+      DeleteReturnReturn(deleted = true)
+    } finally cs.close()
   }
 
   private def processReturnSummary(rs: ResultSet): ReturnSummary =

--- a/app/uk/gov/hmrc/formpproxy/sdlt/services/ReturnService.scala
+++ b/app/uk/gov/hmrc/formpproxy/sdlt/services/ReturnService.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.formpproxy.sdlt.services
 
 import uk.gov.hmrc.formpproxy.sdlt.models.*
 import uk.gov.hmrc.formpproxy.sdlt.models.agents.*
-import uk.gov.hmrc.formpproxy.sdlt.models.returns.SdltReturnRecordResponse
+import uk.gov.hmrc.formpproxy.sdlt.models.returns.{ReturnsForPurgeResponse, SdltReturnRecordResponse}
 import uk.gov.hmrc.formpproxy.sdlt.models.vendor.*
 import uk.gov.hmrc.formpproxy.sdlt.models.purchaser.*
 import uk.gov.hmrc.formpproxy.sdlt.models.land.*
@@ -41,6 +41,12 @@ class ReturnService @Inject() (repo: SdltFormpRepository) {
 
   def getSDLTReturns(request: GetReturnRecordsRequest): Future[SdltReturnRecordResponse] =
     repo.sdltGetReturns(request)
+
+  def getSDLTReturnsForPurge(request: GetReturnsForPurgeRequest): Future[ReturnsForPurgeResponse] =
+    repo.sdltGetReturnsForPurge(request)
+
+  def deleteSDLTReturn(req: DeleteReturnRequest): Future[DeleteReturnReturn] =
+    repo.sdltDeleteReturn(req)
 
   def createVendor(req: CreateVendorRequest): Future[CreateVendorReturn] =
     repo.sdltCreateVendor(req)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -52,7 +52,9 @@ POST       /cis/verification/submission/update                      uk.gov.hmrc.
 
 POST       /create/return                                           uk.gov.hmrc.formpproxy.sdlt.controllers.returns.ReturnsController.createSDLTReturn()
 POST       /retrieve-return                                         uk.gov.hmrc.formpproxy.sdlt.controllers.returns.ReturnsController.getSDLTReturn()
+POST       /delete/return                                           uk.gov.hmrc.formpproxy.sdlt.controllers.returns.ReturnsController.deleteSDLTReturn()
 POST       /returns                                                 uk.gov.hmrc.formpproxy.sdlt.controllers.returns.ReturnsController.getSDLTReturns()
+POST       /returns-for-purge                                       uk.gov.hmrc.formpproxy.sdlt.controllers.returns.ReturnsController.getSDLTReturnsForPurge()
 
 
 

--- a/it/test/uk/gov/hmrc/formpproxy/sdlt/DONOTDELETE/ReturnsForPurgeIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/formpproxy/sdlt/DONOTDELETE/ReturnsForPurgeIntegrationSpec.scala
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//package uk.gov.hmrc.formpproxy.sdlt.DONOTDELETE
+//
+//import org.scalatest.BeforeAndAfterEach
+//import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+//import org.scalatest.matchers.must.Matchers
+//import org.scalatest.wordspec.AnyWordSpec
+//import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+//import play.api.db.{DBApi, Database}
+//import uk.gov.hmrc.formpproxy.sdlt.models.{DeleteReturnRequest, GetReturnsForPurgeRequest}
+//import uk.gov.hmrc.formpproxy.sdlt.repositories.SdltFormpRepository
+//
+//import java.time.LocalDate
+//
+//class ReturnsForPurgeIntegrationSpec
+//  extends AnyWordSpec
+//    with Matchers
+//    with ScalaFutures
+//    with IntegrationPatience
+//    with GuiceOneAppPerSuite
+//    with BeforeAndAfterEach {
+//
+//  private def db: Database =
+//    app.injector.instanceOf[DBApi].database("sdlt")
+//
+//  private lazy val repo = app.injector.instanceOf[SdltFormpRepository]
+//
+//  override protected def beforeEach(): Unit = {
+//    super.beforeEach()
+//    cleanupTestReturns()
+//    setupTestReturns()
+//  }
+//
+//  "getReturnsForPurge" should {
+//
+//    "returns the returns due for purge and excludes those not yet due" in {
+//      val request = GetReturnsForPurgeRequest(
+//        purgeDate = LocalDate.parse("2026-06-29")
+//      )
+//
+//      val result = repo.sdltGetReturnsForPurge(request).futureValue
+//
+//      val resourceRefs = result.returnsForPurge.map(_.returnResourceRef)
+//      resourceRefs must contain ("9000001")
+//      resourceRefs must contain ("9000002")
+//      resourceRefs must not contain ("9000003")
+//      resourceRefs must not contain ("9000004")
+//    }
+//
+//    "maps each due return to its storn, return resource ref and status" in {
+//      val request = GetReturnsForPurgeRequest(
+//        purgeDate = LocalDate.parse("2026-06-29")
+//      )
+//
+//      val result = repo.sdltGetReturnsForPurge(request).futureValue
+//
+//      val dueReturn = result.returnsForPurge.find(_.returnResourceRef == "9000001").get
+//      dueReturn.storn mustBe "STN700"
+//      dueReturn.status mustBe "SUBMITTED"
+//    }
+//
+//    "includes a submitted return on the 30-day boundary and a return on the 90-day boundary" in {
+//      val request = GetReturnsForPurgeRequest(
+//        purgeDate = LocalDate.parse("2026-06-29")
+//      )
+//
+//      val result = repo.sdltGetReturnsForPurge(request).futureValue
+//
+//      val resourceRefs = result.returnsForPurge.map(_.returnResourceRef)
+//      resourceRefs must contain ("9000010")
+//      resourceRefs must contain ("9000013")
+//      resourceRefs must contain ("9000015")
+//    }
+//
+//    "excludes returns that are one day short of the 30-day and 90-day windows" in {
+//      val request = GetReturnsForPurgeRequest(
+//        purgeDate = LocalDate.parse("2026-06-29")
+//      )
+//
+//      val result = repo.sdltGetReturnsForPurge(request).futureValue
+//
+//      val resourceRefs = result.returnsForPurge.map(_.returnResourceRef)
+//      resourceRefs must not contain ("9000011")
+//      resourceRefs must not contain ("9000014")
+//    }
+//
+//    "excludes a non-submitted return older than 30 days but less than 90 days" in {
+//      val request = GetReturnsForPurgeRequest(
+//        purgeDate = LocalDate.parse("2026-06-29")
+//      )
+//
+//      val result = repo.sdltGetReturnsForPurge(request).futureValue
+//
+//      val resourceRefs = result.returnsForPurge.map(_.returnResourceRef)
+//      resourceRefs must not contain ("9000012")
+//    }
+//  }
+//
+//  "deleteReturn" should {
+//
+//    "deletes the return and its child rows so it is no longer due for purge" in {
+//      val deleteRequest = DeleteReturnRequest(
+//        storn = "STN700",
+//        returnResourceRef = "9000001"
+//      )
+//
+//      repo.sdltDeleteReturn(deleteRequest).futureValue.deleted mustBe true
+//
+//      val request = GetReturnsForPurgeRequest(
+//        purgeDate = LocalDate.parse("2026-06-29")
+//      )
+//
+//      val result = repo.sdltGetReturnsForPurge(request).futureValue
+//      result.returnsForPurge.map(_.returnResourceRef) must not contain ("9000001")
+//
+//      countRowsForReturn("RETURN", 7000001L) mustBe 0
+//      countRowsForReturn("SUBMISSION", 7000001L) mustBe 0
+//      countRowsForReturn("TRANSACTION", 7000001L) mustBe 0
+//    }
+//
+//    "fails when the return does not exist" in {
+//      val deleteRequest = DeleteReturnRequest(
+//        storn = "STN700",
+//        returnResourceRef = "9999999"
+//      )
+//
+//      repo.sdltDeleteReturn(deleteRequest).failed.futureValue mustBe a[java.sql.SQLException]
+//    }
+//  }
+//
+//  private def setupTestReturns(): Unit = {
+//    db.withConnection { conn =>
+//      val orgStatement = conn.prepareStatement(
+//        """
+//          |INSERT INTO SDLT_FILE_DATA.SDLT_ORGANISATION (STORN, CREATE_DATE, LAST_UPDATE_DATE)
+//          |VALUES (?, SYSDATE, SYSDATE)""".stripMargin
+//      )
+//
+//      orgStatement.setString(1, "STN700")
+//      orgStatement.execute()
+//      orgStatement.close()
+//
+//      val returnStatement = conn.prepareStatement(
+//        """
+//          |INSERT INTO SDLT_FILE_DATA.RETURN (RETURN_ID, STORN, PURCHASER_COUNTER, VENDOR_COUNTER, LAND_COUNTER, PURGE_DATE, RETURN_RESOURCE_REF, STATUS, CREATE_DATE, LAST_UPDATE_DATE)
+//          |VALUES (?, 'STN700', 1, 1, 1, TO_DATE(?, 'YYYY-MM-DD'), ?, ?, TO_DATE(?, 'YYYY-MM-DD'), TO_DATE(?, 'YYYY-MM-DD'))
+//          |""".stripMargin
+//      )
+//
+//      val returnTestData = Seq(
+//        (7000001L, "2020-01-01", 9000001L, "SUBMITTED", "2020-01-01", "2020-01-01"), // DUE (submitted, purge date over 30 days old)
+//        (7000002L, "2020-01-01", 9000002L, "STARTED", "2020-01-01", "2020-01-01"),   // DUE (any status, purge date over 90 days old)
+//        (7000003L, "2099-01-01", 9000003L, "SUBMITTED", "2026-01-01", "2026-01-01"), // NOT DUE (purge date in the future)
+//        (7000004L, "2099-01-01", 9000004L, "STARTED", "2026-01-01", "2026-01-01")    // NOT DUE (purge date in the future)
+//      )
+//
+//      returnTestData.foreach { case (returnId, purgeDate, resourceRef, status, createdDate, lastUpdateDate) =>
+//        returnStatement.setLong(1, returnId)
+//        returnStatement.setString(2, purgeDate)
+//        returnStatement.setLong(3, resourceRef)
+//        returnStatement.setString(4, status)
+//        returnStatement.setString(5, createdDate)
+//        returnStatement.setString(6, lastUpdateDate)
+//        returnStatement.addBatch()
+//      }
+//      returnStatement.executeBatch()
+//      returnStatement.close()
+//
+//      val boundaryReturnStatement = conn.prepareStatement(
+//        """
+//          |INSERT INTO SDLT_FILE_DATA.RETURN (RETURN_ID, STORN, PURCHASER_COUNTER, VENDOR_COUNTER, LAND_COUNTER, PURGE_DATE, RETURN_RESOURCE_REF, STATUS, CREATE_DATE, LAST_UPDATE_DATE)
+//          |VALUES (?, 'STN700', 1, 1, 1, TRUNC(SYSDATE) - ?, ?, ?, SYSDATE, SYSDATE)
+//          |""".stripMargin
+//      )
+//
+//      val boundaryTestData = Seq(
+//        (7000010L, 30, 9000010L, "SUBMITTED"),
+//        (7000011L, 29, 9000011L, "SUBMITTED"),
+//        (7000012L, 31, 9000012L, "STARTED"),
+//        (7000013L, 90, 9000013L, "STARTED"),
+//        (7000014L, 89, 9000014L, "STARTED"),
+//        (7000015L, 30, 9000015L, "SUBMITTED_NO_RECEIPT")
+//      )
+//
+//      boundaryTestData.foreach { case (returnId, daysAgo, resourceRef, status) =>
+//        boundaryReturnStatement.setLong(1, returnId)
+//        boundaryReturnStatement.setInt(2, daysAgo)
+//        boundaryReturnStatement.setLong(3, resourceRef)
+//        boundaryReturnStatement.setString(4, status)
+//        boundaryReturnStatement.addBatch()
+//      }
+//      boundaryReturnStatement.executeBatch()
+//      boundaryReturnStatement.close()
+//
+//      val submissionStatement = conn.prepareStatement(
+//        """
+//          |INSERT INTO SDLT_FILE_DATA.SUBMISSION (SUBMISSION_ID, RETURN_ID, STORN, SUBMITTED_DATE, CREATE_DATE, LAST_UPDATE_DATE)
+//          |VALUES (?, ?, 'STN700', TO_DATE(?, 'YYYY-MM-DD'), TO_DATE(?, 'YYYY-MM-DD'), TO_DATE(?, 'YYYY-MM-DD'))
+//          |""".stripMargin
+//      )
+//
+//      val submissionTestData = Seq(
+//        (8000001L, 7000001L, "2020-01-01", "2020-01-01", "2020-01-01")
+//      )
+//
+//      submissionTestData.foreach { case (submissionId, returnId, submittedDate, createdDate, lastUpdateDate) =>
+//        submissionStatement.setLong(1, submissionId)
+//        submissionStatement.setLong(2, returnId)
+//        submissionStatement.setString(3, submittedDate)
+//        submissionStatement.setString(4, createdDate)
+//        submissionStatement.setString(5, lastUpdateDate)
+//        submissionStatement.addBatch()
+//      }
+//      submissionStatement.executeBatch()
+//      submissionStatement.close()
+//
+//      val transactionStatement = conn.prepareStatement(
+//        """
+//          |INSERT INTO SDLT_FILE_DATA.TRANSACTION (TRANSACTION_ID, RETURN_ID, TRANSACTION_DESCRIPTION, CREATE_DATE, LAST_UPDATE_DATE)
+//          |VALUES (?, ?, ?, SYSDATE, SYSDATE)
+//          |""".stripMargin
+//      )
+//
+//      transactionStatement.setLong(1, 8500001L)
+//      transactionStatement.setLong(2, 7000001L)
+//      transactionStatement.setString(3, "F")
+//      transactionStatement.execute()
+//      transactionStatement.close()
+//    }
+//  }
+//
+//  private def cleanupTestReturns(): Unit = {
+//    db.withConnection { conn =>
+//      val cleanupSubmissionsStatement = conn.prepareStatement(
+//        """
+//          |DELETE FROM SDLT_FILE_DATA.SUBMISSION
+//          |WHERE STORN = 'STN700'
+//          |""".stripMargin
+//      )
+//      cleanupSubmissionsStatement.execute()
+//      cleanupSubmissionsStatement.close()
+//
+//      val cleanupTransactionsStatement = conn.prepareStatement(
+//        """
+//          |DELETE FROM SDLT_FILE_DATA.TRANSACTION
+//          |WHERE RETURN_ID IN (SELECT RETURN_ID FROM SDLT_FILE_DATA.RETURN WHERE STORN = 'STN700')
+//          |""".stripMargin
+//      )
+//      cleanupTransactionsStatement.execute()
+//      cleanupTransactionsStatement.close()
+//
+//      val cleanupReturnsStatement = conn.prepareStatement(
+//        """
+//          |DELETE FROM SDLT_FILE_DATA.RETURN
+//          |WHERE STORN = 'STN700'
+//          |""".stripMargin
+//      )
+//      cleanupReturnsStatement.execute()
+//      cleanupReturnsStatement.close()
+//
+//      val cleanupOrgStatement = conn.prepareStatement(
+//        """
+//          |DELETE FROM SDLT_FILE_DATA.SDLT_ORGANISATION
+//          |WHERE STORN = 'STN700'
+//          |""".stripMargin
+//      )
+//      cleanupOrgStatement.execute()
+//      cleanupOrgStatement.close()
+//    }
+//  }
+//
+//  private def countRowsForReturn(table: String, returnId: Long): Int =
+//    db.withConnection { conn =>
+//      val statement = conn.prepareStatement(
+//        s"SELECT COUNT(*) FROM SDLT_FILE_DATA.$table WHERE RETURN_ID = ?"
+//      )
+//      statement.setLong(1, returnId)
+//      val resultSet = statement.executeQuery()
+//      try {
+//        resultSet.next()
+//        resultSet.getInt(1)
+//      } finally {
+//        resultSet.close()
+//        statement.close()
+//      }
+//    }
+//}

--- a/test/uk/gov/hmrc/formpproxy/sdlt/controllers/ReturnsControllerSpec.scala
+++ b/test/uk/gov/hmrc/formpproxy/sdlt/controllers/ReturnsControllerSpec.scala
@@ -30,7 +30,7 @@ import uk.gov.hmrc.formpproxy.actions.{AuthAction, FakeAuthAction}
 import uk.gov.hmrc.formpproxy.sdlt.controllers.returns.ReturnsController
 import uk.gov.hmrc.formpproxy.sdlt.models.*
 import uk.gov.hmrc.formpproxy.sdlt.models.purchaser.{UpdateReturnRequest, UpdateReturnReturn}
-import uk.gov.hmrc.formpproxy.sdlt.models.returns.ReturnSummary
+import uk.gov.hmrc.formpproxy.sdlt.models.returns.{ReturnForPurge, ReturnSummary}
 import uk.gov.hmrc.formpproxy.sdlt.repositories.SdltFormpRepoDataHelper
 import uk.gov.hmrc.formpproxy.sdlt.services.ReturnService
 import uk.gov.hmrc.http.UpstreamErrorResponse
@@ -408,6 +408,107 @@ class ReturnsControllerSpec
 
       status(res) mustBe INTERNAL_SERVER_ERROR
       (contentAsJson(res) \ "message").as[String] mustBe "Unexpected error::getSDLTReturns"
+    }
+  }
+
+  "ReturnsController getSDLTReturnsForPurge" - {
+
+    "returns 200 with the returns due for purge when the service succeeds" in new Setup {
+      when(mockService.getSDLTReturnsForPurge(eqTo(requestReturnsForPurge)))
+        .thenReturn(Future.successful(returnsForPurgeResponse))
+      val req: FakeRequest[JsValue] = makeJsonReturnsForPurgeRequest(Json.toJson(requestReturnsForPurge))
+      val res: Future[Result]       = controller.getSDLTReturnsForPurge()(req)
+
+      status(res) mustBe OK
+      contentType(res) mustBe Some(JSON)
+
+      val json: JsValue = contentAsJson(res)
+      (json \ "returnsForPurge").as[List[ReturnForPurge]] mustBe expectedReturnsForPurge
+
+      verify(mockService).getSDLTReturnsForPurge(eqTo(requestReturnsForPurge))
+      verifyNoMoreInteractions(mockService)
+    }
+
+    "returns 400 when the JSON body is invalid, without calling the service" in new Setup {
+      val req: FakeRequest[JsValue] = makeJsonReturnsForPurgeRequest(Json.toJson(requestReturnsInvalid))
+      val res: Future[Result]       = controller.getSDLTReturnsForPurge()(req)
+
+      status(res) mustBe BAD_REQUEST
+
+      verify(mockService, times(0)).getSDLTReturnsForPurge(eqTo(requestReturnsForPurge))
+      verifyNoMoreInteractions(mockService)
+    }
+
+    "returns the upstream status when FORMP responds with an error" in new Setup {
+      val req: FakeRequest[JsValue]  = makeJsonReturnsForPurgeRequest(Json.toJson(requestReturnsForPurge))
+      val err: UpstreamErrorResponse = UpstreamErrorResponse("FORMP service unavailable", BAD_GATEWAY, BAD_GATEWAY)
+
+      when(mockService.getSDLTReturnsForPurge(eqTo(requestReturnsForPurge)))
+        .thenReturn(Future.failed(err))
+
+      val res: Future[Result] = controller.getSDLTReturnsForPurge()(req)
+
+      status(res) mustBe BAD_GATEWAY
+      (contentAsJson(res) \ "message").as[String] must include("FORMP service unavailable")
+    }
+
+    "returns 500 with a generic message on an unexpected exception" in new Setup {
+      val req: FakeRequest[JsValue] = makeJsonReturnsForPurgeRequest(Json.toJson(requestReturnsForPurge))
+
+      when(mockService.getSDLTReturnsForPurge(eqTo(requestReturnsForPurge)))
+        .thenReturn(Future.failed(new RuntimeException("Database timeout")))
+
+      val res: Future[Result] = controller.getSDLTReturnsForPurge()(req)
+
+      status(res) mustBe INTERNAL_SERVER_ERROR
+      (contentAsJson(res) \ "message").as[String] mustBe "Unexpected error"
+    }
+  }
+
+  "ReturnsController deleteSDLTReturn" - {
+
+    "returns 200 with the deleted flag when the service succeeds" in new Setup {
+      val request: DeleteReturnRequest = DeleteReturnRequest(
+        storn = "STORN12345",
+        returnResourceRef = "100001"
+      )
+
+      when(mockService.deleteSDLTReturn(eqTo(request)))
+        .thenReturn(Future.successful(DeleteReturnReturn(deleted = true)))
+
+      val req: FakeRequest[JsValue] = makeJsonRequest(Json.toJson(request))
+      val res: Future[Result]       = controller.deleteSDLTReturn()(req)
+
+      status(res) mustBe OK
+      contentType(res) mustBe Some(JSON)
+      (contentAsJson(res) \ "deleted").as[Boolean] mustBe true
+
+      verify(mockService).deleteSDLTReturn(eqTo(request))
+      verifyNoMoreInteractions(mockService)
+    }
+
+    "returns 400 when the JSON body is invalid, without calling the service" in new Setup {
+      val req: FakeRequest[JsValue] = makeJsonRequest(Json.obj("storn" -> "STORN12345"))
+      val res: Future[Result]       = controller.deleteSDLTReturn()(req)
+
+      status(res) mustBe BAD_REQUEST
+      verifyNoMoreInteractions(mockService)
+    }
+
+    "returns 500 with a generic message on an unexpected exception" in new Setup {
+      val request: DeleteReturnRequest = DeleteReturnRequest(
+        storn = "STORN12345",
+        returnResourceRef = "100001"
+      )
+
+      when(mockService.deleteSDLTReturn(eqTo(request)))
+        .thenReturn(Future.failed(new RuntimeException("database error")))
+
+      val req: FakeRequest[JsValue] = makeJsonRequest(Json.toJson(request))
+      val res: Future[Result]       = controller.deleteSDLTReturn()(req)
+
+      status(res) mustBe INTERNAL_SERVER_ERROR
+      (contentAsJson(res) \ "message").as[String] mustBe "Unexpected error"
     }
   }
 
@@ -890,6 +991,11 @@ class ReturnsControllerSpec
 
     def makeJsonReturnsRequest(body: JsValue): FakeRequest[JsValue] =
       FakeRequest(POST, "/formp-proxy/sdlt/returns")
+        .withHeaders(CONTENT_TYPE -> JSON, ACCEPT -> JSON)
+        .withBody(body)
+
+    def makeJsonReturnsForPurgeRequest(body: JsValue): FakeRequest[JsValue] =
+      FakeRequest(POST, "/formp-proxy/sdlt/returns-for-purge")
         .withHeaders(CONTENT_TYPE -> JSON, ACCEPT -> JSON)
         .withBody(body)
 

--- a/test/uk/gov/hmrc/formpproxy/sdlt/repositories/SdltFormpRepoDataHelper.scala
+++ b/test/uk/gov/hmrc/formpproxy/sdlt/repositories/SdltFormpRepoDataHelper.scala
@@ -17,8 +17,8 @@
 package uk.gov.hmrc.formpproxy.sdlt.repositories
 
 import play.api.libs.json.{Json, OFormat}
-import uk.gov.hmrc.formpproxy.sdlt.models.GetReturnRecordsRequest
-import uk.gov.hmrc.formpproxy.sdlt.models.returns.{ReturnSummary, SdltReturnRecordResponse}
+import uk.gov.hmrc.formpproxy.sdlt.models.{GetReturnRecordsRequest, GetReturnsForPurgeRequest}
+import uk.gov.hmrc.formpproxy.sdlt.models.returns.{ReturnForPurge, ReturnSummary, ReturnsForPurgeResponse, SdltReturnRecordResponse}
 
 import java.time.LocalDate
 
@@ -83,5 +83,18 @@ trait SdltFormpRepoDataHelper {
     deletionFlag = false,
     pageType = None,
     pageNumber = None
+  )
+
+  val expectedReturnsForPurge: List[ReturnForPurge]      = List(
+    ReturnForPurge(storn = "STORN12345", returnResourceRef = "REF01", status = "SUBMITTED"),
+    ReturnForPurge(storn = "STORN12345", returnResourceRef = "REF02", status = "STARTED")
+  )
+  val expectedReturnsForPurgeEmpty: List[ReturnForPurge] = List.empty
+  val returnsForPurgeResponse: ReturnsForPurgeResponse   = ReturnsForPurgeResponse(
+    returnsForPurge = expectedReturnsForPurge
+  )
+
+  val requestReturnsForPurge: GetReturnsForPurgeRequest = GetReturnsForPurgeRequest(
+    purgeDate = LocalDate.parse("2026-06-29")
   )
 }

--- a/test/uk/gov/hmrc/formpproxy/sdlt/repositories/SdltFormpRepositorySpec.scala
+++ b/test/uk/gov/hmrc/formpproxy/sdlt/repositories/SdltFormpRepositorySpec.scala
@@ -21,7 +21,7 @@ import org.mockito.Mockito.*
 import play.api.db.Database
 import uk.gov.hmrc.formpproxy.base.SpecBase
 import uk.gov.hmrc.formpproxy.sdlt.models.*
-import uk.gov.hmrc.formpproxy.sdlt.models.returns.{ReturnSummary, SdltReturnRecordResponse}
+import uk.gov.hmrc.formpproxy.sdlt.models.returns.{ReturnForPurge, ReturnSummary, ReturnsForPurgeResponse, SdltReturnRecordResponse}
 import uk.gov.hmrc.formpproxy.sdlt.models.vendor.*
 import uk.gov.hmrc.formpproxy.sdlt.models.purchaser.*
 import uk.gov.hmrc.formpproxy.sdlt.models.agents.*
@@ -871,6 +871,99 @@ final class SdltFormpRepositorySpec extends SpecBase with SdltFormpRepoDataHelpe
 
       verify(cs).setString(8, "submitted_date")
       verify(cs).setString(9, "DESC")
+      verify(cs).execute()
+      verify(cs).close()
+    }
+  }
+
+  "sdltGetReturnsForPurge" - {
+    "call get_returns_for_purge and map each cursor row to a ReturnForPurge" in new ReturnsFixture {
+
+      when(db.withConnection(anyArg[Connection => Any])).thenAnswer { inv =>
+        val f = inv.getArgument(0, classOf[Connection => Any]);
+        f(conn)
+      }
+
+      when(
+        conn.prepareCall(
+          eqTo("{ call RETURN_PROCS.get_returns_for_purge(?, ?) }")
+        )
+      ).thenReturn(cs)
+
+      when(cs.getObject(eqTo(2), eqTo(classOf[ResultSet]))).thenReturn(resRetSummary)
+
+      when(resRetSummary.next()).thenReturn(true, true, false)
+      when(resRetSummary.getString("storn")).thenReturn("STORN12345", "STORN12345")
+      when(resRetSummary.getString("return_resource_ref")).thenReturn("REF01", "REF02")
+      when(resRetSummary.getString("status")).thenReturn("SUBMITTED", "STARTED")
+
+      val repo = new SdltFormpRepository(db)
+
+      val result = repo.sdltGetReturnsForPurge(requestReturnsForPurge).futureValue
+
+      result.returnsForPurge.length mustBe 2
+      result.returnsForPurge mustBe expectedReturnsForPurge
+
+      verify(conn).prepareCall(
+        eqTo("{ call RETURN_PROCS.get_returns_for_purge(?, ?) }")
+      )
+      verify(cs).setDate(1, Date.valueOf(requestReturnsForPurge.purgeDate))
+      verify(cs).execute()
+      verify(cs).close()
+    }
+
+    "call get_returns_for_purge and return an empty list when no returns are due for purge" in new ReturnsFixture {
+
+      when(db.withConnection(anyArg[Connection => Any])).thenAnswer { inv =>
+        val f = inv.getArgument(0, classOf[Connection => Any]);
+        f(conn)
+      }
+
+      when(
+        conn.prepareCall(
+          eqTo("{ call RETURN_PROCS.get_returns_for_purge(?, ?) }")
+        )
+      ).thenReturn(cs)
+
+      when(cs.getObject(eqTo(2), eqTo(classOf[ResultSet]))).thenReturn(resRetSummary)
+
+      when(resRetSummary.next()).thenReturn(false)
+
+      val repo = new SdltFormpRepository(db)
+
+      val result: ReturnsForPurgeResponse = repo.sdltGetReturnsForPurge(requestReturnsForPurge).futureValue
+      result.returnsForPurge.length mustBe 0
+      result.returnsForPurge mustBe expectedReturnsForPurgeEmpty
+    }
+  }
+
+  "sdltDeleteReturn" - {
+
+    "call delete_return stored procedure with correct parameters" in {
+      val db   = mock[Database]
+      val conn = mock[Connection]
+      val cs   = mock[CallableStatement]
+
+      when(db.withTransaction(anyArg[Connection => Any])).thenAnswer { inv =>
+        val f = inv.getArgument(0, classOf[Connection => Any]); f(conn)
+      }
+
+      when(conn.prepareCall(eqTo("{ call RETURN_PROCS.delete_return(?, ?) }"))).thenReturn(cs)
+
+      val repo = new SdltFormpRepository(db)
+
+      val request = DeleteReturnRequest(
+        storn = "STORN12345",
+        returnResourceRef = "100001"
+      )
+
+      val result = repo.sdltDeleteReturn(request).futureValue
+
+      result.deleted mustBe true
+
+      verify(conn).prepareCall("{ call RETURN_PROCS.delete_return(?, ?) }")
+      verify(cs).setString(1, "STORN12345")
+      verify(cs).setLong(2, 100001L)
       verify(cs).execute()
       verify(cs).close()
     }

--- a/test/uk/gov/hmrc/formpproxy/sdlt/services/ReturnServiceSpec.scala
+++ b/test/uk/gov/hmrc/formpproxy/sdlt/services/ReturnServiceSpec.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.formpproxy.sdlt.models.residency.*
 import uk.gov.hmrc.formpproxy.sdlt.models.transaction.*
 import uk.gov.hmrc.formpproxy.sdlt.models.lease.*
 import uk.gov.hmrc.formpproxy.sdlt.models.taxCalculation.*
-import uk.gov.hmrc.formpproxy.sdlt.models.returns.SdltReturnRecordResponse
+import uk.gov.hmrc.formpproxy.sdlt.models.returns.{ReturnsForPurgeResponse, SdltReturnRecordResponse}
 import uk.gov.hmrc.formpproxy.sdlt.repositories.{SdltFormpRepoDataHelper, SdltFormpRepository}
 
 import scala.concurrent.Future
@@ -545,6 +545,39 @@ final class ReturnServiceSpec extends SpecBase with SdltFormpRepoDataHelper {
       result mustBe actualResponse
 
       verify(repo).sdltGetReturns(eqTo(requestReturns))
+      verifyNoMoreInteractions(repo)
+    }
+  }
+
+  "ReturnService getSDLTReturnsForPurge" - {
+    "delegate to the repository" in new ReturnsFixture {
+
+      when(repo.sdltGetReturnsForPurge(eqTo(requestReturnsForPurge)))
+        .thenReturn(Future.successful(returnsForPurgeResponse))
+
+      val result: ReturnsForPurgeResponse = service.getSDLTReturnsForPurge(requestReturnsForPurge).futureValue
+      result mustBe returnsForPurgeResponse
+
+      verify(repo).sdltGetReturnsForPurge(eqTo(requestReturnsForPurge))
+      verifyNoMoreInteractions(repo)
+    }
+  }
+
+  "ReturnService deleteSDLTReturn" - {
+    "delegate to the repository" in new ReturnsFixture {
+      val request: DeleteReturnRequest         = DeleteReturnRequest(
+        storn = "STORN12345",
+        returnResourceRef = "100001"
+      )
+      val expectedResponse: DeleteReturnReturn = DeleteReturnReturn(deleted = true)
+
+      when(repo.sdltDeleteReturn(eqTo(request)))
+        .thenReturn(Future.successful(expectedResponse))
+
+      val result: DeleteReturnReturn = service.deleteSDLTReturn(request).futureValue
+      result mustBe expectedResponse
+
+      verify(repo).sdltDeleteReturn(eqTo(request))
       verifyNoMoreInteractions(repo)
     }
   }


### PR DESCRIPTION
# What does this PR do?

## POST /returns-for-purge                                                                                                                                                                    
- Returns the returns that are old enough to be deleted.                                                                                                                                                
- It calls the **[GET_RETURNS_FOR_PURGE](https://github.com/hmrc/prh-oracle-xe/blob/main/databases/sdlt/scripts/bodies.pkb#L5587-L5624)** stored procedure, which, in turn, selects all returns based on how long they've been sitting past their purge date (details below):    
  - **SUBMITTED || SUBMITTED_NO_RECEIPT** returns when purge date is **30+ days ago**                                                                 
  - anything else (eg **STARTED**) when purge date is **90+ days ago**                                                                                                                                             

  **Example request**
  ```json
  {
    "purgeDate": "2026-06-29"
  }
  ```

  **Example response** `200 OK`
  ```json
  {
    "returnsForPurge": [
      { "storn": "STN700", "returnResourceRef": "9000001", "status": "SUBMITTED" },
      { "storn": "STN700", "returnResourceRef": "9000002", "status": "STARTED" }
    ]
  }
  ``` 

## POST /delete/return
- pass it a **storn** + **returnResourceRef**
- It calls the **[Delete_Return](https://github.com/hmrc/prh-oracle-xe/blob/main/databases/sdlt/scripts/bodies.pkb#L3443-L3573)** stored procedure, which, in turn, deletes that return and all its child rows (transaction, purchaser etc...)

  **Example request**
  ```json
  {
    "storn": "STN700",
    "returnResourceRef": "9000001"
  }
  ```

  **Example response** `200 OK`
  ```json
  {
    "deleted": true
  }
  ```

## Intended flow:
- call `/returns-for-purge` for the list, then loop `/delete/return` over each one. That loop will be driven by the scheduled purge job (using Quartz Scheduler in the Backend, this will be in another PR).

## Out of the box stored procedure behaviour we get for free:

- Every time a user opens a return (**[get_return](https://github.com/hmrc/prh-oracle-xe/blob/main/databases/sdlt/scripts/bodies.pkb#L4111)** calls **[update_purge_date](https://github.com/hmrc/prh-oracle-xe/blob/main/databases/sdlt/scripts/bodies.pkb#L3357)**), that return's deletion timer is reset, therefore pushing its purge date forward so it won't be purged.

## Test output:

<img width="802" height="272" alt="image" src="https://github.com/user-attachments/assets/8bb3942d-7f38-43d2-bfea-502d9a270ab7" />
<img width="622" height="91" alt="image" src="https://github.com/user-attachments/assets/7a907b34-e36c-42d7-b261-0e7b5bf5ee1b" />
<img width="623" height="73" alt="image" src="https://github.com/user-attachments/assets/5f8b872a-8211-4050-b193-55102c1bfb3a" />
